### PR TITLE
Update MediaAttributes.java

### DIFF
--- a/src/main/java/org/mcsoxford/rss/MediaAttributes.java
+++ b/src/main/java/org/mcsoxford/rss/MediaAttributes.java
@@ -40,7 +40,7 @@ final class MediaAttributes {
    */
   static int intValue(org.xml.sax.Attributes attributes, String name, int defaultValue) {
     final String value = stringValue(attributes, name);
-    if(value == null) {
+    if((value == null) || (value.isEmpty())) {
       return defaultValue;
     }
 
@@ -54,7 +54,7 @@ final class MediaAttributes {
 	 */
 	static Integer intValue(org.xml.sax.Attributes attributes, String name) {
 		final String value = stringValue(attributes, name);
-		if (value == null) {
+		if ((value == null)|| (value.isEmpty())) {
 			return null;
 		}
 		return Integers.parseInteger(value);


### PR DESCRIPTION
Fix for https://github.com/ahorn/android-rss/issues/32:  
**Error:** NumberFormatException while loading the rss feed 
**Cause:** Empty string. The only check done in intValue function is for a null string. 
**Fix:** Added check for empty string to return the default value